### PR TITLE
Update lint instructions and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Contribuições são bem-vindas! Por favor, siga estas diretrizes:
 ### Padrões de Código
 
 - Use ESLint e Prettier para formatação
+- Antes de rodar `npm run lint`, instale as dependências de desenvolvimento com `npm install` ou `pnpm install` (você pode executar `./setup.sh` para automatizar essa etapa)
 - Siga convenções de nomenclatura React
 - Escreva testes para novas funcionalidades
 - Documente mudanças no README

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Simple setup script to install dependencies
+if command -v pnpm >/dev/null 2>&1; then
+  pnpm install
+else
+  npm install
+fi


### PR DESCRIPTION
## Summary
- update README with dev dependency installation instructions before running `npm run lint`
- add simple `setup.sh` script to install dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686aae066b2483238d4e6b31595f12a6