### PR TITLE
Add exercises using transliterated vocabulary

### DIFF
--- a/src/data/exercises.js
+++ b/src/data/exercises.js
@@ -26,6 +26,14 @@ export const exercises = {
         options: ['Esperança', 'Amor', 'Fé', 'Paz'],
         correct: 2,
         explanation: '"Faith" significa "fé" - confiança e crença em Deus.'
+      },
+      {
+        id: 'fund_easy_4',
+        type: 'multiple_choice',
+        question: 'Na lição de Vocabulário Básico, o termo grego ἀγάπη (agápē) refere-se a:',
+        options: ['Amor', 'Pecado', 'Igreja', 'Lei'],
+        correct: 0,
+        explanation: 'Agápē é a transliteração de ἀγάπη, palavra grega para o amor divino.'
       }
     ],
     medium: [
@@ -44,6 +52,14 @@ export const exercises = {
         options: ['teach', 'teaches', 'teaching', 'taught'],
         correct: 1,
         explanation: 'Terceira pessoa do singular no Present Simple adiciona "s" ao verbo.'
+      },
+      {
+        id: 'fund_med_3',
+        type: 'multiple_choice',
+        question: 'O termo grego θεός, transliterado "theós", significa:',
+        options: ['Oração', 'Deus', 'Graça', 'Profeta'],
+        correct: 1,
+        explanation: 'Theós é a palavra grega para Deus, conforme explicado na lição de Fonologia.'
       }
     ],
     hard: [
@@ -54,6 +70,14 @@ export const exercises = {
         options: ['Emoldurados', 'Criados/Formados', 'Destruídos', 'Pintados'],
         correct: 1,
         explanation: 'No contexto teológico, "framed" significa "criados" ou "formados" por Deus.'
+      },
+      {
+        id: 'fund_hard_2',
+        type: 'multiple_choice',
+        question: 'Na terminologia teológica, "λόγος" (logos) transliterado é usado em João 1 como título para:',
+        options: ['Pedro', 'O Verbo/Palavra', 'A Lei', 'O Espírito'],
+        correct: 1,
+        explanation: 'Logos significa "Palavra" ou "Verbo" e é aplicado a Cristo em João 1.'
       }
     ]
   },
@@ -74,6 +98,14 @@ export const exercises = {
         options: ['die', 'dies', 'died', 'dying'],
         correct: 2,
         explanation: 'Past Simple "died" para indicar um evento histórico específico.'
+      },
+      {
+        id: 'gram_easy_3',
+        type: 'multiple_choice',
+        question: 'O verbo grego σώζω (sōzō - "salvar") no Past Simple do inglês é:',
+        options: ['saves', 'saved', 'saving', 'to save'],
+        correct: 1,
+        explanation: 'A forma passada "saved" corresponde ao pretérito do verbo grego sōzō.'
       }
     ],
     medium: [
@@ -92,6 +124,14 @@ export const exercises = {
         options: ['The world created by God', 'The world was created by God', 'The world is created by God', 'The world has created by God'],
         correct: 1,
         explanation: 'Voz passiva no passado: was/were + particípio passado.'
+      },
+      {
+        id: 'gram_med_3',
+        type: 'multiple_choice',
+        question: 'A expressão δικαιόω (dikaioō) transliterada aparece muitas vezes como "to justify". Qual estrutura em inglês apresenta a voz passiva no Present Perfect?',
+        options: ['has justified', 'has been justified', 'is justifying', 'was justified'],
+        correct: 1,
+        explanation: '"Has been justified" expressa a voz passiva no Present Perfect.'
       }
     ],
     hard: [
@@ -102,6 +142,14 @@ export const exercises = {
         options: ['Oração principal', 'Particípio passado absoluto', 'Gerúndio simples', 'Infinitivo'],
         correct: 1,
         explanation: '"Having been justified" é um particípio passado absoluto indicando causa ou tempo anterior.'
+      },
+      {
+        id: 'gram_hard_2',
+        type: 'multiple_choice',
+        question: 'A forma grega ἐκλήθη (eklēthē) significa "foi chamado". Como essa voz passiva é melhor expressa em inglês?',
+        options: ['called', 'was called', 'has call', 'calling'],
+        correct: 1,
+        explanation: '"Was called" traduz adequadamente a voz passiva do grego eklēthē.'
       }
     ]
   },
@@ -122,6 +170,14 @@ export const exercises = {
         options: ['Santificação', 'Salvação', 'Sacrifício', 'Sacramento'],
         correct: 1,
         explanation: '"Salvation" significa "salvação" - libertação do pecado através de Cristo.'
+      },
+      {
+        id: 'vocab_easy_3',
+        type: 'multiple_choice',
+        question: 'O termo λόγος (logos) transliterado significa:',
+        options: ['Amor', 'Palavra', 'Paz', 'Servo'],
+        correct: 1,
+        explanation: 'Logos significa "palavra" ou "verbo" em grego.'
       }
     ],
     medium: [
@@ -140,6 +196,14 @@ export const exercises = {
         options: ['Livre arbítrio humano', 'Escolha divina eterna dos salvos', 'Processo de santificação', 'Segunda vinda de Cristo'],
         correct: 1,
         explanation: 'Predestinação é a doutrina de que Deus escolheu eternamente quem seria salvo.'
+      },
+      {
+        id: 'vocab_med_3',
+        type: 'multiple_choice',
+        question: 'Koinōnía (κοινωνία) transliterado refere-se principalmente a:',
+        options: ['Comunhão', 'Rebelião', 'Sacrifício', 'Templo'],
+        correct: 0,
+        explanation: 'Koinōnía é a palavra grega para "comunhão" ou "participação".'
       }
     ],
     hard: [
@@ -150,6 +214,14 @@ export const exercises = {
         options: ['Apenas criação inicial', 'Governo e preservação contínua da criação', 'Somente eventos futuros', 'Apenas milagres'],
         correct: 1,
         explanation: 'Providência inclui o governo e cuidado contínuo de Deus sobre toda a criação.'
+      },
+      {
+        id: 'vocab_hard_2',
+        type: 'multiple_choice',
+        question: 'O vocábulo grego χάρις (charis), transliterado, é fundamental para a doutrina da:',
+        options: ['Eleição', 'Graça', 'Glória', 'Criação'],
+        correct: 1,
+        explanation: 'Charis significa graça, conceito central na soteriologia reformada.'
       }
     ]
   },
@@ -162,6 +234,14 @@ export const exercises = {
         options: ['Scanning', 'Skimming', 'Leitura detalhada', 'Tradução palavra por palavra'],
         correct: 1,
         explanation: 'Skimming é a técnica para obter uma visão geral rápida do texto.'
+      },
+      {
+        id: 'read_easy_2',
+        type: 'multiple_choice',
+        question: 'O conectivo "therefore" (διό, dío) em um texto indica:',
+        options: ['Contraste', 'Conclusão ou resultado', 'Exemplo', 'Definição'],
+        correct: 1,
+        explanation: 'O grego διό (dío), traduzido "therefore", introduz uma conclusão baseada no que foi dito.'
       }
     ],
     medium: [
@@ -172,6 +252,14 @@ export const exercises = {
         options: ['Skimming', 'Scanning', 'Inferência', 'Memorização'],
         correct: 1,
         explanation: 'Scanning é usado para localizar informações específicas rapidamente.'
+      },
+      {
+        id: 'read_med_2',
+        type: 'multiple_choice',
+        question: 'Ao ler "ekklesia" (ἐκκλησία, ekklēsia), qual tradução deve vir à mente?',
+        options: ['Trono', 'Igreja', 'Profecia', 'Sacrifício'],
+        correct: 1,
+        explanation: 'Ekklesia significa "igreja" ou "assembleia".'
       }
     ],
     hard: [
@@ -182,6 +270,14 @@ export const exercises = {
         options: ['Contraste', 'Adição/Continuação', 'Causa', 'Conclusão'],
         correct: 1,
         explanation: '"Moreover" é um conectivo que indica adição ou continuação do argumento.'
+      },
+      {
+        id: 'read_hard_2',
+        type: 'multiple_choice',
+        question: 'Em "ἀγάπη (agápē) never fails", o termo "agápē" reforça que tipo de amor?',
+        options: ['Amor condicional', 'Amor sacrificial', 'Amor romântico', 'Amor próprio'],
+        correct: 1,
+        explanation: 'Agápē descreve o amor sacrificial e incondicional frequentemente mencionado no NT.'
       }
     ]
   }


### PR DESCRIPTION
## Summary
- expand each difficulty section in `src/data/exercises.js`
- new questions cite Greek terms with transliterations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686aae01ecfc83238f146a5dbb1c530b